### PR TITLE
gemfileUpdate - tzinfo error resolved

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,6 @@ gem 'jekyll-bits', '0.15'
 gem 'jekyll-feed', '0.5.1'
 gem 'jekyll-paginate', '1.1.0'
 gem 'jekyll-sitemap', '0.10.0'
+
+gem "tzinfo", "~> 2.0"
+gem "tzinfo-data", platforms: [:x64_mingw, :mingw, :mswin]


### PR DESCRIPTION
added 2 lines (tzinfo and tzinfo-data) to the Gemfile which help Ruby work ok with Windows. DO NOT delete those lines or it may lead to the TZInfo: :DataSourceNotFoundError